### PR TITLE
Allow outputting emails in DevAdapter

### DIFF
--- a/src/carbon/adapters/dev_adapter.cr
+++ b/src/carbon/adapters/dev_adapter.cr
@@ -1,8 +1,15 @@
 class Carbon::DevAdapter < Carbon::Adapter
   class_getter delivered_emails = [] of Carbon::Email
 
+  def initialize(print_emails = false)
+    @print_emails = print_emails
+  end
+
   def deliver_now(email : Carbon::Email)
     @@delivered_emails << email
+    if @print_emails
+      print_email(email)
+    end
   end
 
   def self.delivered?(email) : Bool
@@ -11,5 +18,20 @@ class Carbon::DevAdapter < Carbon::Adapter
 
   def self.reset
     @@delivered_emails.clear
+  end
+
+  private def print_email(email : Carbon::Email)
+    puts(
+        "#{"To:".colorize(:green)} #{email.to}",
+        "#{"From:".colorize(:green)} #{email.from}",
+        "#{"Subject:".colorize(:green)} #{email.subject}",
+        "#{"CC:".colorize(:green)} #{email.cc}",
+        "#{"BCC:".colorize(:green)} #{email.bcc}",
+        "#{"Headers:".colorize(:green)} #{email.headers}",
+        "======= TEXT =======".colorize(:green),
+        email.text_body,
+        "======= HTML =======".colorize(:green),
+        email.html_body
+      )
   end
 end

--- a/src/carbon/address.cr
+++ b/src/carbon/address.cr
@@ -18,4 +18,16 @@ class Carbon::Address
   def emailable
     self
   end
+
+  def to_s(io : IO)
+    io << to_s
+  end
+
+  def to_s : String
+    if @name
+      "\"#{@name}\" <#{@address}>"
+    else
+      @address
+    end
+  end
 end


### PR DESCRIPTION
This resolves #14 . 

Feel free to give any feedback on the code or even just the styling. I'm just starting out with Crystal and have no Ruby background so I am likely far from idiomatic. 

I presented the headers differently for the text and HTML bodies because those pieces can be very verbose and nice to have a clearer separation around.