### PR TITLE
Handle namespaced class names on templates

### DIFF
--- a/spec/deliver_later_strategy_spec.cr
+++ b/spec/deliver_later_strategy_spec.cr
@@ -31,7 +31,7 @@ describe "Deliver later strategy" do
 end
 
 private def use_custom_strategy(strategy)
-  CustomizedBaseEmail.configure do
+  CustomizedBaseEmail.configure do |settings|
     settings.adapter = Carbon::DevAdapter.new
     settings.deliver_later_strategy = strategy
   end

--- a/spec/email_spec.cr
+++ b/spec/email_spec.cr
@@ -18,6 +18,12 @@ private class EmailWithTemplates < BareMinimumEmail
   templates text, html
 end
 
+private module Namespaced
+  class EmailWithTemplates < BareMinimumEmail
+    templates text, html
+  end
+end
+
 private class CustomizedRecipientsEmail < BareMinimumEmail
   cc "cc@example.com"
   bcc ["bcc@example.com"]
@@ -97,6 +103,13 @@ describe Carbon::Email do
 
     email.text_body.should contain "text template"
     email.html_body.should contain "html template"
+  end
+
+  it "can render templates on a namespaced class" do
+    email = Namespaced::EmailWithTemplates.new
+
+    email.text_body.should contain "namespaced text template"
+    email.html_body.should contain "namespaced html template"
   end
 
   it "can customize headers" do

--- a/spec/templates/namespaced_email_with_templates/html.ecr
+++ b/spec/templates/namespaced_email_with_templates/html.ecr
@@ -1,0 +1,1 @@
+namespaced html template

--- a/spec/templates/namespaced_email_with_templates/text.ecr
+++ b/spec/templates/namespaced_email_with_templates/text.ecr
@@ -1,0 +1,1 @@
+namespaced text template

--- a/src/carbon/email.cr
+++ b/src/carbon/email.cr
@@ -28,7 +28,7 @@ abstract class Carbon::Email
       \{% for content_type in content_types %}
         def \{{ content_type }}_body : String
           io = IO::Memory.new
-          ECR.embed "#{__DIR__}/templates/\{{ @type.name.underscore }}/\{{ content_type }}.ecr", io
+          ECR.embed "#{__DIR__}/templates/\{{ @type.name.underscore.gsub(/::/, "_") }}/\{{ content_type }}.ecr", io
           io.to_s
         end
       \{% end %}


### PR DESCRIPTION
When using Emails::Invite for the class name, instead of InviteEmail, the default template handler attempts to include files from templates/emails::invite/ whereas this should also respect namespaced templates. This has been achieved using gsub to replace any remaining double colon tokens with an underscore.

Spec fix courtesy of https://github.com/luckyframework/carbon/pull/18