### PR TITLE
Adding SMTP adapter based on Crystal EMail

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.1
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: 0.30.0
+crystal: 0.31.1
 
 license: MIT
 
@@ -12,7 +12,8 @@ dependencies:
   habitat:
     github: luckyframework/habitat
   email:
-    github: arcage/crystal-email
+    github: anykeyh/crystal-email
+    branch: master
 
 development_dependencies:
   dotenv:

--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,8 @@ license: MIT
 dependencies:
   habitat:
     github: luckyframework/habitat
+  email:
+    github: arcage/crystal-email
 
 development_dependencies:
   dotenv:

--- a/spec/smtp_adapter_spec.cr
+++ b/spec/smtp_adapter_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+require "email"
+
+describe Carbon::SMTPAdapter do
+  it "can use smtp adapter" do
+
+    domain = ENV.fetch("SMTP_MAIL_DOMAIN")
+    username = ENV.fetch("SMTP_MAIL_USERNAME")
+    password = ENV.fetch("SMTP_MAIL_PASSWORD")
+    port = ENV.fetch("SMTP_MAIL_PORT").to_i
+
+    config = EMail::Client::Config.new(domain, port)
+    config.use_auth(username, password)
+    config.use_tls
+
+    email = FakeEmail.new(
+      from: Carbon::Address.new("noreply@ticketsdev.helpcube.net"),
+      to: [Carbon::Address.new("yacine@helpcube.net")],
+      subject: "I'm just testing to send an email",
+      text_body: "This is a text body and it should work\nWell.",
+      html_body: "This is the <strong>html version</strong> and should work<br>too."
+      )
+    adapter = Carbon::SMTPAdapter.new(config)
+    adapter.deliver_now(email)
+  end
+end

--- a/spec/smtp_adapter_spec.cr
+++ b/spec/smtp_adapter_spec.cr
@@ -9,13 +9,16 @@ describe Carbon::SMTPAdapter do
     password = ENV.fetch("SMTP_MAIL_PASSWORD")
     port = ENV.fetch("SMTP_MAIL_PORT").to_i
 
+    sender = ENV.fetch("TEST_TO"){ "you@example.com" }
+    from = ENV.fetch("TEST_FROM"){ "me@example.com" }
+
     config = EMail::Client::Config.new(domain, port)
     config.use_auth(username, password)
     config.use_tls
 
     email = FakeEmail.new(
-      from: Carbon::Address.new("noreply@ticketsdev.helpcube.net"),
-      to: [Carbon::Address.new("yacine@helpcube.net")],
+      from: Carbon::Address.new(sender),
+      to: [Carbon::Address.new(from)],
       subject: "I'm just testing to send an email",
       text_body: "This is a text body and it should work\nWell.",
       html_body: "This is the <strong>html version</strong> and should work<br>too."

--- a/src/carbon/adapters/smtp_adapter.cr
+++ b/src/carbon/adapters/smtp_adapter.cr
@@ -1,0 +1,53 @@
+require "email"
+
+class Carbon::SMTPAdapter < Carbon::Adapter
+  @client : EMail::Client?
+
+  def initialize(@config : EMail::Client::Config)
+
+  end
+
+  def client :  EMail::Client
+    @client ||= EMail::Client.new(@config)
+  end
+
+  def self.carbon_email_to_crystal_email( email : Carbon::Email)
+    output = EMail::Message.new
+    output.from EMail::Address.new(email.from.address, email.from.name)
+
+    email.to.each do |dest|
+      output.to EMail::Address.new(dest.address, dest.name)
+    end
+
+    output.subject email.subject
+
+    email.cc.each do |carbon_copy_dest|
+      output.cc EMail::Address.new(carbon_copy_dest.address, carbon_copy_dest.name)
+    end
+
+    email.bcc.each do |hidden_carbon_copy_dest|
+      output.cc EMail::Address.new(hidden_carbon_copy_dest.address, hidden_carbon_copy_dest.name)
+    end
+
+    if text_body = email.text_body
+      output.message text_body
+    end
+
+    if html_body = email.html_body
+      output.message_html html_body
+    end
+
+    email.headers.each do |key, value|
+      output.custom_header key, value
+    end
+
+    output
+  end
+
+  def deliver_now(email : Carbon::Email)
+    client.start do
+      send Carbon::SMTPAdapter.carbon_email_to_crystal_email(email)
+    end
+  end
+
+end


### PR DESCRIPTION
## What

Send email through SMTP server. It uses  [arcage/crystal-email](https://github.com/arcage/crystal-email) under the hood.

## Why

Because not everybody is using SendGrid to send email! 
Most of the people are using SMTP to send email :o)


## Note

Currently as draft as:
- The adapter is not yet properly tested
- The CI env should be changed
- crystal-email shard have some bugs I'm waiting the owner to fix (arcage/crystal-email#49)
