### PR TITLE
Release v0.1.2

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: carbon
-version: 0.1.1
+version: 0.1.2
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   habitat:
     github: luckyframework/habitat
-    branch: jaw/v0.5.0
+    version: ~> 0.4.4
 
 development_dependencies:
   dotenv:

--- a/shard.yml
+++ b/shard.yml
@@ -4,15 +4,16 @@ version: 0.1.1
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: 0.30.0
+crystal: 0.35.0
 
 license: MIT
 
 dependencies:
   habitat:
     github: luckyframework/habitat
+    branch: jaw/v0.5.0
 
 development_dependencies:
   dotenv:
     github: gdotdesign/cr-dotenv
-    version: 0.2.0
+    version: 0.7.0

--- a/src/carbon/version.cr
+++ b/src/carbon/version.cr
@@ -1,3 +1,3 @@
 module Carbon
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
shards requires Habitat to specify a version now.