### PR TITLE
Add GitHub Action for crystal format/spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Lucky Flow CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: "*"
+
+jobs:
+  check_format:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:0.35.0
+    steps:
+      - uses: actions/checkout@v1
+      - name: Format
+        run: crystal tool format --check
+  specs:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:0.35.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install shards
+        run: shards install
+      - name: Cache Crystal
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/crystal
+          key: ${{ runner.os }}-crystal
+      - name: Create .env file
+        run: touch .env
+      - name: Run tests
+        run: crystal spec -D skip-integration


### PR DESCRIPTION
Adds some basic formatting and `crystal spec` checks to default GitHub actions for all master pushes and PRs.

Using the `skip-integration` flag so that Paul doesn't get a bunch of emails, but we'll probably need to change that up in the future as well!