### PR TITLE
lock ameba to latest 0.13 due to a bug in 0.14

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -19,5 +19,5 @@ development_dependencies:
     version: 0.7.0
 
   ameba:
-    github: veelenga/ameba
-    version: ~> 0.13
+    github: crystal-ameba/ameba
+    version: ~> 0.13.4


### PR DESCRIPTION
0.14 throws a ton of new suggestions which in some cases aren't always the best suggestions. For now we can stick with the 0.13 branch.