### PR TITLE
Adding adapter for sparkpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dependencies:
 - `Carbon::SendInBlueAdapter` - See [atnos/carbon_send_in_blue_adapter](https://github.com/atnos/carbon_send_in_blue_adapter).
 - `Carbon::MailgunAdapter` - See [atnos/carbon_mailgun_adapter](https://github.com/atnos/carbon_mailgun_adapter).
 - `Carbon::SmtpAdapter` - See [oneiros/carbon_smtp_adapter](https://github.com/oneiros/carbon_smtp_adapter).
+- `Carbon::SparkPostAdapter` - See [Swiss-Crystal/carbon_sparkpost_adapter](https://github.com/Swiss-Crystal/carbon_sparkpost_adapter).
 - `Carbon::PostmarkAdapter` - See [makisu/carbon_postmark_adapter](https://github.com/makisu/carbon_postmark_adapter).
 
 ## Usage


### PR DESCRIPTION
A group of us are currently looking into crystal/lucky as a replacement for rails and are in the process of porting some gems which we want to use for a first prototype.
As we were not able to find a sparkpost adapter we wrote one, in order to use our existing infrastructure / services.

The current version is basic and will be expanded if the need arises(or if we just want to expand it for fun).