### PR TITLE
Lock to Crystal 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,14 @@ jobs:
   check_format:
     strategy:
       fail-fast: false
-      matrix:
-        crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
-          - 1.3.0
-        experimental:
-          - false
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
+    continue-on-error: false
     steps:
       - uses: actions/checkout@v1
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
       - name: Install shards
         run: shards install
       - name: Format
@@ -34,22 +29,17 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
-          - 1.3.0
+          - 1.4.0
+          - latest
         experimental:
           - false
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     steps:
       - uses: actions/checkout@v2
-      - name: Cache Crystal
-        uses: actions/cache@v1
+      - uses: crystal-lang/install-crystal@v1
         with:
-          path: ~/.cache/crystal
-          key: ${{ runner.os }}-crystal
+          crystal: ${{matrix.crystal_version}}
       - name: Install dependencies
         run: shards install
       - name: Create .env file

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,12 +7,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:0.36.1
     steps:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - uses: crystal-lang/install-crystal@v1
       - name: "Install shards"
         run: shards install
       - name: "Generate docs"

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.1
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: ">= 1.0.0"
+crystal: ">= 1.4.0"
 
 license: MIT
 
@@ -32,7 +32,7 @@ development_dependencies:
     version: ~> 0.1.4
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.3
+    version: ~> 1.0.0
 
 scripts:
   postinstall: BUILD_WITHOUT_DEVELOPMENT=true script/precompile_tasks


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
