### PR TITLE
Normalizing the email name in gen email task

### DIFF
--- a/spec/tasks/email_spec.cr
+++ b/spec/tasks/email_spec.cr
@@ -12,4 +12,14 @@ describe Gen::Email do
       generator.output.to_s.should contain("src/emails/templates/password_reset_email/html.ecr")
     end
   end
+
+  it "doesn't duplicate the word Email" do
+    with_cleanup do
+      generator = Gen::Email.new
+      generator.output = IO::Memory.new
+      generator.print_help_or_call ["WelcomeUserEmail"]
+
+      generator.output.to_s.should contain("src/emails/templates/welcome_user_email/html.ecr")
+    end
+  end
 end

--- a/src/carbon/tasks/gen/email.cr
+++ b/src/carbon/tasks/gen/email.cr
@@ -31,14 +31,18 @@ class Gen::Email < LuckyTask::Task
   end
 
   def call
-    template = Carbon::EmailTemplate.new(filename, email_name)
+    template = Carbon::EmailTemplate.new(filename, normalized_email_name)
     template.render(output_path.to_s)
 
     display_success_messages
   end
 
+  private def normalized_email_name : String
+    email_name.gsub(/email$/i, "")
+  end
+
   private def filename : String
-    Wordsmith::Inflector.underscore(email_name)
+    Wordsmith::Inflector.underscore(normalized_email_name)
   end
 
   private def output_path : Path


### PR DESCRIPTION
Fixes #73

Before the PR:
`lucky gen.email WelcomeEmail`  generated `welcome_email_email.cr` now it doesn't