### PR TITLE
Attachments and Body Resources

### DIFF
--- a/src/carbon/attachment.cr
+++ b/src/carbon/attachment.cr
@@ -1,0 +1,7 @@
+module Carbon
+  alias AttachFile = NamedTuple(file_path: String, file_name: String?, mime_type: String?)
+  alias AttachIO = NamedTuple(io: IO, file_name: String, mime_type: String?)
+  alias ResourceFile = NamedTuple(file_path: String, cid: String, file_name: String?, mime_type: String?)
+  alias ResourceIO = NamedTuple(io: IO, cid: String, file_name: String, mime_type: String?)
+  alias Attachment = AttachFile | AttachIO | ResourceFile | ResourceIO
+end

--- a/src/carbon/email.cr
+++ b/src/carbon/email.cr
@@ -8,7 +8,7 @@ abstract class Carbon::Email
   abstract def from : Carbon::Address
   abstract def to : Array(Carbon::Address)
 
-  def_equals subject, from, to, cc, bcc, headers, text_body, html_body
+  def_equals subject, from, to, cc, bcc, headers, text_body, html_body, attachments
 
   # Set this value to `false` to prevent the email from
   # being delivered
@@ -88,6 +88,18 @@ abstract class Carbon::Email
   macro subject(value)
     def subject : String
       id_or_method({{ value }})
+    end
+  end
+
+  @attachments = [] of Carbon::Attachment
+  getter attachments
+
+  macro attachment(value)
+    def attachments : Array(Carbon::Attachment)
+      {% if @type.methods.map(&.name).includes?("attachments".id) %}
+        previous_def
+      {% end %}
+      @attachments << {{value}}
     end
   end
 


### PR DESCRIPTION
This allows adding Attachments when specifying an Email.

The fields of `Carbon::Attachment` were chosen based on the ones required in the SMTP library carbon_smtp_adapter uses: https://github.com/arcage/crystal-email/blob/master/src/email/message.cr#L353-L382

I'd imagine the same data may be used by all other adapters.

example usage:

```crystal
class TestEmail < BaseEmail
  from Carbon::Address.new("My App Name", "support@myapp.com")
  to "fred@example.org"
  subject "Test Subject"
  templates text, html
  attachment hello

  def bye
    {
      io: IO::Memory.new("Bye"),
      cid: "unique_bar@myapp.com",
      file_name: "bye.txt",
      mime_type: "text/plain"
    }
  end
end
```

Please note that I did fold both attachments and body resources into a single Array, this is mostly to keep our API simple, the only difference being the presence of the `cid` property.