### PR TITLE
Fixing the location where the new emails get generated.

### DIFF
--- a/spec/tasks/email_spec.cr
+++ b/spec/tasks/email_spec.cr
@@ -9,6 +9,7 @@ describe Gen::Email do
       generator = Gen::Email.new
       generator.output = IO::Memory.new
       generator.print_help_or_call ["PasswordReset"]
+      generator.output.to_s.should contain("src/emails/password_reset_email.cr")
       generator.output.to_s.should contain("src/emails/templates/password_reset_email/html.ecr")
 
       folder = generator.email_template.template_folder
@@ -21,6 +22,7 @@ describe Gen::Email do
       generator = Gen::Email.new
       generator.output = IO::Memory.new
       generator.print_help_or_call ["WelcomeUserEmail"]
+      generator.output.to_s.should contain("src/emails/welcome_user_email.cr")
       generator.output.to_s.should contain("src/emails/templates/welcome_user_email/html.ecr")
 
       folder = generator.email_template.template_folder

--- a/src/carbon/tasks/gen/email.cr
+++ b/src/carbon/tasks/gen/email.cr
@@ -13,16 +13,18 @@ class Carbon::EmailTemplate
 
   def template_folder
     LuckyTemplate.create_folder do |top_dir|
-      top_dir.add_folder(Path["src/emails/templates"]) do |templates_dir|
-        templates_dir.add_file("#{@email_filename}_email.cr") do |io|
+      top_dir.add_folder(Path["src/emails"]) do |email_dir|
+        email_dir.add_file("#{@email_filename}_email.cr") do |io|
           ECR.embed("#{__DIR__}/templates/email.cr.ecr", io)
         end
-        templates_dir.add_folder("#{@email_filename}_email") do |email_templates_dir|
-          email_templates_dir.add_file("html.ecr") do |io|
-            ECR.embed("#{__DIR__}/templates/html.ecr.ecr", io)
-          end
-          email_templates_dir.add_file("text.ecr") do |io|
-            ECR.embed("#{__DIR__}/templates/text.ecr.ecr", io)
+        email_dir.add_folder(Path["templates"]) do |templates_dir|
+          templates_dir.add_folder("#{@email_filename}_email") do |email_templates_dir|
+            email_templates_dir.add_file("html.ecr") do |io|
+              ECR.embed("#{__DIR__}/templates/html.ecr.ecr", io)
+            end
+            email_templates_dir.add_file("text.ecr") do |io|
+              ECR.embed("#{__DIR__}/templates/text.ecr.ecr", io)
+            end
           end
         end
       end


### PR DESCRIPTION
Fixes #89

This moves the email file to the proper location of `src/emails/` instead of the nested `src/emails/templates`