### PR TITLE
Release v0.6.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: carbon
-version: 0.5.1
+version: 0.6.0
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>

--- a/src/carbon/version.cr
+++ b/src/carbon/version.cr
@@ -1,3 +1,3 @@
 module Carbon
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
This release changes the postinstall requirements to support Windows. The `gen.email` task is no longer precompiled